### PR TITLE
make ZORP_PIDFILEDIR consistent

### DIFF
--- a/zorpctl_in_cc/szig.cc
+++ b/zorpctl_in_cc/szig.cc
@@ -244,7 +244,7 @@ z_szig_context_new(const char *instance_name)
   if (fd == -1)
     return NULL;
   unaddr.sun_family = AF_UNIX;
-  snprintf(unaddr.sun_path, sizeof(unaddr.sun_path), ZORP_PIDFILEDIR "zorpctl.%s", instance_name);
+  snprintf(unaddr.sun_path, sizeof(unaddr.sun_path), ZORP_PIDFILEDIR "/zorpctl.%s", instance_name);
   if (connect(fd, (struct sockaddr *) &unaddr, sizeof(unaddr)) < 0)
     {
       close(fd);


### PR DESCRIPTION
This pull request is to make ZORP_PIDFILEDIR consistent with other configure options.

If one configures Zorp with '--with-pidfiledir=/run/zorp' (without ending slash) parameter, Zorpctl would run into pid file naming error and try connect to wrong path:

```
connect(5, {sa_family=AF_LOCAL, sun_path="/run/zorpzorpctl.zorp_any#0"}, 110) = -1 ENOENT (No such file or directory)
```