### PR TITLE
Fix bad documentation about SSLV23 protocol

### DIFF
--- a/pylib/Zorp/Encryption.py
+++ b/pylib/Zorp/Encryption.py
@@ -82,7 +82,7 @@
         <item>
           <name>SSL_METHOD_SSLV23</name>
           <description>
-           Permit the use of SSLv2 and v3.
+           Permit the use of all the supported (SSLv2, SSLv3, TLSv1, TLSv1_1 and TLSv1_2) protocols.
           </description>
         </item>
         <item>
@@ -112,7 +112,7 @@
         <item>
           <name>SSL_METHOD_ALL</name>
           <description>
-           Permit the use of all the supported (SSLv2, SSLv3, and TLSv1) protocols.
+           Permit the use of all the supported (SSLv2, SSLv3, TLSv1, TLSv1_1 and TLSv1_2) protocols.
           </description>
         </item>
       </enum>


### PR DESCRIPTION
As said on Debian bug 805112 [1], SSLV23 is actually up to TLS1.2

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=805112
```
grep SSL_METHOD_ALL . -R
./pylib/Zorp/Encryption.py:SSL_METHOD_ALL          = "SSLv23"
```